### PR TITLE
Add workaround for invalid MIT cookie

### DIFF
--- a/src/cdm
+++ b/src/cdm
@@ -128,6 +128,8 @@ else
 		elif [[ $dpyinfo = No\ protocol\ specified* ]]; then
 			# Display is in use by another user
 			let display=display+1
+		elif [[ $dpyinfo = Invalid\ MIT* ]];then
+			let display=display+1
 		else
 			break
 		fi


### PR DESCRIPTION
Sometimes the auto-incrementing doesn't work because of an "Invalid MIT cookie" or something along those lines. This causes issues like [this](https://bbs.archlinux.org/viewtopic.php?pid=1000701#p1000701).
