### PR TITLE
Fixed bug in handling the default value of 'binlist' array

### DIFF
--- a/src/cdm
+++ b/src/cdm
@@ -89,8 +89,8 @@ if [[ "$binlist" == "()" ]]; then
     binlist=($(find /etc/X11/Sessions -maxdepth 1 -type f))
     for ((i=0; i<${#binlist[@]}; i++)); do
         declare flaglist[$i]="X"
+        declare namelist[$i]=$(basename ${binlist[$i]})
     done
-    namelist=(${binlist[@]^})
 fi
 
 # Generate the main menu.


### PR DESCRIPTION
The default value of 'binlist' array was handled incorrectly. When initialized as '()', the length of array as reported by '${#binlist[@]}' was 1, not 0, so cdm exited with "\* cdm: unknown flag: `()'." when used with empty (or default) config.
