### PR TITLE
Small change to call to startx, run in subshell.

### DIFF
--- a/src/cdm-xlaunch
+++ b/src/cdm-xlaunch
@@ -76,8 +76,7 @@ if $consolekit; then
     dbuspid=$(<"$dbuspidfifo"); rm -f "$dbuspidfifo"
 fi
 
-# Conform to POSIX and do not use `>&' here.
-setsid startx "$@" > /dev/null 2>&1 &
+$(setsid startx "$@" > /dev/null 2>&1) &
 
 # If wait(1) returns with a value >128, it was interrupted by kill(1),
 # so registration was sucessful.


### PR DESCRIPTION
`cdm` didn't do/start anything without this change on my system, Ubuntu 12.10, `$BASH_VERSION=4.2.37(1)-release`.

After being able to trace it back to `setsid startx ...` line, the problem seemed to be the fork of `setsid`. If I didn't fork (no `&`), it worked but the script waited for return of setsid/startx.

This patch backgrounds the subshell in which `setsid` runs, which works for me but it seems it is quite finicky about the setsid command.

It might be helpful if there was some discussion about what works on different systems (and maybe why it works/doesn't work).
