### PR TITLE
cdm-xlaunch: fix typo introduced in commit 3c8e2bab

### DIFF
--- a/src/cdm-xlaunch
+++ b/src/cdm-xlaunch
@@ -82,7 +82,7 @@ fi
 
 if $altstartx; then
     # Alternative method of calling setsid(/startx) for systems that are unresponsive to the 'normal' call.
-    (setsid startx "$@" > /dev/null 2>&1) &
+    (setsid startx "$@" > /dev/null 2>&1 &)
 else
     setsid startx "$@" > /dev/null 2>&1 &
 fi


### PR DESCRIPTION
cdm-xlaunch: fix typo introduced in commit 3c8e2bab.
