### PR TITLE
Added optional logging of startx output

### DIFF
--- a/src/cdm
+++ b/src/cdm
@@ -78,6 +78,7 @@ locktty=${locktty:-no}
 consolekit=${consolekit:-yes}
 cktimeout=${cktimeout:-30}
 altstartx=${altstartx:-no}
+startxlog="${startxlog:-/dev/null}"
 [[ -z "${binlist[*]}" ]] && binlist=()
 [[ -z "${namelist[*]}" ]] && namelist=()
 [[ -z "${flaglist[*]}" ]] && flaglist=()
@@ -201,6 +202,7 @@ case ${flaglist[$binindex]} in
 
         $(yesno consolekit) && launchflags=(-c -t "$cktimeout")
         $(yesno altstartx) && launchflags=("${launchflags[@]}" --altstartx)
+        launchflags=("${launchflags[@]}" --startxlog "$startxlog")
         if cdm-xlaunch "${launchflags[@]}" -- "${bin[@]}" -- "${serverargs[@]}"
         then
             exitnormal

--- a/src/cdm-xlaunch
+++ b/src/cdm-xlaunch
@@ -32,11 +32,12 @@ name=$(basename "$0")
 consolekit=false
 cktimeout=30
 altstartx=false
+startxlog=/dev/null
 
 info() { printf ' \033[01;32m*\033[00m '; echo "$name: $*"; }
 error() { (printf ' \033[01;31m*\033[00m '; echo "$name: $*") > /dev/stderr; }
 
-args=$(getopt -n "$name" -o ct: -l consolekit,timeout,altstartx: -- "$@") || exit 1
+args=$(getopt -n "$name" -o ct: -l consolekit,timeout:,altstartx,startxlog: -- "$@") || exit 1
 eval set -- "$args"
 for arg in "$@"
 do
@@ -50,6 +51,10 @@ do
             ;;
         '--altstartx')
             altstartx=true; shift
+            ;;
+        '--startxlog')
+            shift
+            startxlog=$1; shift
             ;;
         '--')
             shift
@@ -82,9 +87,9 @@ fi
 
 if $altstartx; then
     # Alternative method of calling setsid(/startx) for systems that are unresponsive to the 'normal' call.
-    (setsid startx "$@" > /dev/null 2>&1 &)
+    (setsid startx "$@" > "$startxlog" 2>&1 &)
 else
-    setsid startx "$@" > /dev/null 2>&1 &
+    setsid startx "$@" > "$startxlog" 2>&1 &
 fi
 
 # If wait(1) returns with a value >128, it was interrupted by kill(1),

--- a/src/cdmrc
+++ b/src/cdmrc
@@ -62,3 +62,6 @@ serverargs=(-nolisten tcp)
 # no apparent reason does not start X).
 # Only provided in the hope it may be useful, not a guaranteed fix.
 altstartx=no
+
+# Destination for stdout and stderr output from startx.
+startxlog=/dev/null


### PR DESCRIPTION
Previously all startx output from cdm-xlaunch was sent to /dev/null.
This commit adds a 'startxlog' configuration option which allows this
behaviour to be overridden.
