### PR TITLE
src/profile.sh: remove bashisms in favour of posix sh syntax.

### DIFF
--- a/src/profile.sh
+++ b/src/profile.sh
@@ -1,8 +1,8 @@
 # To avoid potential situation where cdm(1) crashes on every TTY, here we
 # default to execute cdm(1) on tty1 only, and leave other TTYs untouched.
-if [[ "$(tty)" == '/dev/tty1' ]]; then
-    [[ -n "$CDM_SPAWN" ]] && return
+if [ "$(tty)" = '/dev/tty1' ]; then
+    [ -n "$CDM_SPAWN" ] && return
     # Avoid executing cdm(1) when X11 has already been started.
-    [[ -z "$DISPLAY$SSH_TTY$(pgrep xinit)" ]] && exec cdm
+    [ -z "$DISPLAY$SSH_TTY$(pgrep xinit)" ] && exec cdm
 fi
 


### PR DESCRIPTION
helps in distros like Void Linux, Debian, Ubuntu, Alpine, etc that don't use `bash` as login shell

it gives this error when run under a system that doesn't use bash as default login shell

-sh: 3: /etc/profile.d/cdm.sh: [[: not found